### PR TITLE
vector tests: add "id" to ok_names

### DIFF
--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -129,7 +129,7 @@ fn test_schema() {
         .map(|f| f.name())
         .collect();
     let ok_names: Vec<String> = vec!(
-        "kind", "sort_key", "is_link", "is_tunnel",
+        "id", "kind", "sort_key", "is_link", "is_tunnel",
         "is_bridge", "railway", "highway")
         .iter().map(|s| s.to_string()).collect();
     assert_eq!(name_list, ok_names);


### PR DESCRIPTION
The schema test fails for me with GDAL 2.x. It seams that "id" is now also reported as a part of the schema. 
