### PR TITLE
Add RasterBand

### DIFF
--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -6,15 +6,15 @@ fn main() {
     use gdal::metadata::Metadata;
 
     let driver = gdal::raster::driver::Driver::get("mem").unwrap();
-    println!("driver description: {:?}", driver.get_description());
+    println!("driver description: {:?}", driver.description());
 
     let path = Path::new("./fixtures/tinymarble.png");
     let dataset = Dataset::open(path).unwrap();
-    println!("dataset description: {:?}", dataset.get_description());
+    println!("dataset description: {:?}", dataset.description());
 
     let key = "INTERLEAVE";
     let domain = "IMAGE_STRUCTURE";
-    let meta = dataset.get_metadata_item(key, domain);
+    let meta = dataset.metadata_item(key, domain);
     println!("domain: {:?} key: {:?} -> value: {:?}", domain, key, meta);
 
 }

--- a/examples/rasterband.rs
+++ b/examples/rasterband.rs
@@ -8,14 +8,14 @@ fn main() {
 
     let path = Path::new("./fixtures/tinymarble.png");
     let dataset = Dataset::open(path).unwrap();
-    println!("dataset description: {:?}", dataset.get_description());
+    println!("dataset description: {:?}", dataset.description());
 
-    let rasterband: RasterBand = dataset.get_rasterband(1).unwrap();
-    println!("rasterband description: {:?}", rasterband.get_description());
-    println!("rasterband no_data_value: {:?}", rasterband.get_no_data_value());
-    println!("rasterband type: {:?}", rasterband.get_band_type());
-    println!("rasterband scale: {:?}", rasterband.get_scale());
-    println!("rasterband offset: {:?}", rasterband.get_offset());
+    let rasterband: RasterBand = dataset.rasterband(1).unwrap();
+    println!("rasterband description: {:?}", rasterband.description());
+    println!("rasterband no_data_value: {:?}", rasterband.no_data_value());
+    println!("rasterband type: {:?}", rasterband.band_type());
+    println!("rasterband scale: {:?}", rasterband.scale());
+    println!("rasterband offset: {:?}", rasterband.offset());
     let rv = rasterband.read_as::<u8>(
         (20, 30),
         (2, 3),

--- a/examples/rasterband.rs
+++ b/examples/rasterband.rs
@@ -1,0 +1,25 @@
+extern crate gdal;
+
+use std::path::Path;
+use gdal::raster::{Dataset, RasterBand};
+use gdal::metadata::Metadata;
+
+fn main() {
+
+    let path = Path::new("./fixtures/tinymarble.png");
+    let dataset = Dataset::open(path).unwrap();
+    println!("dataset description: {:?}", dataset.get_description());
+
+    let rasterband: RasterBand = dataset.get_rasterband(1).unwrap();
+    println!("rasterband description: {:?}", rasterband.get_description());
+    println!("rasterband no_data_value: {:?}", rasterband.get_no_data_value());
+    println!("rasterband type: {:?}", rasterband.get_band_type());
+    println!("rasterband scale: {:?}", rasterband.get_scale());
+    println!("rasterband offset: {:?}", rasterband.get_offset());
+    let rv = rasterband.read_as::<u8>(
+        (20, 30),
+        (2, 3),
+        (2, 3)
+    );
+    println!("{:?}", rv.data);
+}

--- a/src/gdal_major_object.rs
+++ b/src/gdal_major_object.rs
@@ -1,5 +1,5 @@
 use libc::{c_void};
 
 pub trait MajorObject {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void;
+    unsafe fn gdal_object_ptr(&self) -> *const c_void;
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -12,8 +12,8 @@ extern {
 
 pub trait Metadata: MajorObject {
 
-    fn get_description(&self) -> Option<String>{
-        let c_res = unsafe { GDALGetDescription(self.get_gdal_object_ptr())};
+    fn description(&self) -> Option<String>{
+        let c_res = unsafe { GDALGetDescription(self.gdal_object_ptr())};
         if c_res.is_null() {
             None
         } else {
@@ -21,10 +21,10 @@ pub trait Metadata: MajorObject {
         }
     }
 
-    fn get_metadata_item(&self, key: &str, domain: &str) -> Option<String> {
+    fn metadata_item(&self, key: &str, domain: &str) -> Option<String> {
         if let Ok(c_key) = CString::new(key.to_owned()) {
             if let Ok(c_domain) = CString::new(domain.to_owned()){
-                let c_res = unsafe { GDALGetMetadataItem(self.get_gdal_object_ptr(), c_key.as_ptr(), c_domain.as_ptr())};
+                let c_res = unsafe { GDALGetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_domain.as_ptr())};
                 if !c_res.is_null() {
                     return Some(_string(c_res));
                 }
@@ -37,7 +37,7 @@ pub trait Metadata: MajorObject {
         if let Ok(c_key) = CString::new(key.to_owned()){
             if let Ok(c_domain) = CString::new(domain.to_owned()){
                 if let Ok(c_value) =  CString::new(value.to_owned()){
-                    let c_res = unsafe { GDALSetMetadataItem(self.get_gdal_object_ptr(), c_key.as_ptr(), c_value.as_ptr(), c_domain.as_ptr())};
+                    let c_res = unsafe { GDALSetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_value.as_ptr(), c_domain.as_ptr())};
                     if c_res == 0 {
                         return Ok(());
                     }

--- a/src/raster/dataset.rs
+++ b/src/raster/dataset.rs
@@ -16,7 +16,7 @@ pub struct Dataset {
 }
 
 impl MajorObject for Dataset {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+    unsafe fn gdal_object_ptr(&self) -> *const c_void {
         self.c_dataset
     }
 }
@@ -51,7 +51,7 @@ impl Dataset {
     }
 
 
-    pub fn get_rasterband<'a>(&'a self, band_index: isize) -> Option<RasterBand<'a>> {
+    pub fn rasterband<'a>(&'a self, band_index: isize) -> Option<RasterBand<'a>> {
         unsafe {
             let c_band = gdal::GDALGetRasterBand(self.c_dataset, band_index as c_int);
             if c_band.is_null() {
@@ -134,8 +134,8 @@ impl Dataset {
         };
     }
 
-    pub fn get_band_type(&self, band_index: isize) -> Option<GDALDataType> {
-        self.get_rasterband(band_index).map(|band| band.get_band_type())
+    pub fn band_type(&self, band_index: isize) -> Option<GDALDataType> {
+        self.rasterband(band_index).map(|band| band.band_type())
     }
 
     /// Read a 'Buffer<u8>' from a 'Dataset'.
@@ -167,7 +167,7 @@ impl Dataset {
         band_index: isize,
     ) -> Option<Buffer<T>>
     {
-        self.get_rasterband(band_index).map(|band| band.read_band_as())
+        self.rasterband(band_index).map(|band| band.read_band_as())
     }
 
     /// Read a 'Buffer<T>' from a 'Dataset'. T implements 'GdalType'
@@ -184,7 +184,7 @@ impl Dataset {
         size: (usize, usize),
     ) -> Option<Buffer<T>>
     {
-        self.get_rasterband(band_index).map(|band| band.read_as(window, window_size, size))
+        self.rasterband(band_index).map(|band| band.read_as(window, window_size, size))
     }
 
     /// Write a 'Buffer<T>' into a 'Dataset'.
@@ -199,7 +199,7 @@ impl Dataset {
         window_size: (usize, usize),
         buffer: Buffer<T>
     ) {
-        self.get_rasterband(band_index).expect("Invalid RasterBand").write(window, window_size, buffer)
+        self.rasterband(band_index).expect("Invalid RasterBand").write(window, window_size, buffer)
     }
 
 }

--- a/src/raster/dataset.rs
+++ b/src/raster/dataset.rs
@@ -2,9 +2,9 @@ use libc::{c_int, c_double, c_void};
 use std::ffi::CString;
 use std::path::Path;
 use utils::_string;
-use raster::{gdal, Driver};
+use raster::{gdal, Driver, RasterBand};
 use raster::driver::_register_drivers;
-use raster::gdal_enums::{GDALRWFlag, GDALAccess, GDALDataType};
+use raster::gdal_enums::{GDALAccess, GDALDataType};
 use raster::types::GdalType;
 use gdal_major_object::MajorObject;
 use metadata::Metadata;
@@ -22,7 +22,6 @@ impl MajorObject for Dataset {
 }
 
 impl Metadata for Dataset {}
-
 
 impl Drop for Dataset {
     fn drop(&mut self) {
@@ -51,9 +50,20 @@ impl Dataset {
         return self.c_dataset;
     }
 
-    pub fn size(&self) -> (isize, isize) {
-        let size_x = unsafe { gdal::GDALGetRasterXSize(self.c_dataset) } as isize;
-        let size_y = unsafe { gdal::GDALGetRasterYSize(self.c_dataset) } as isize;
+
+    pub fn get_rasterband<'a>(&'a self, band_index: isize) -> Option<RasterBand<'a>> {
+        unsafe {
+            let c_band = gdal::GDALGetRasterBand(self.c_dataset, band_index as c_int);
+            if c_band.is_null() {
+                return None;
+            }
+            Some(RasterBand::_with_c_ptr(c_band, self))
+        }
+    }
+
+    pub fn size(&self) -> (usize, usize) {
+        let size_x = unsafe { gdal::GDALGetRasterXSize(self.c_dataset) } as usize;
+        let size_y = unsafe { gdal::GDALGetRasterYSize(self.c_dataset) } as usize;
         return (size_x, size_y);
     }
 
@@ -124,6 +134,10 @@ impl Dataset {
         };
     }
 
+    pub fn get_band_type(&self, band_index: isize) -> Option<GDALDataType> {
+        self.get_rasterband(band_index).map(|band| band.get_band_type())
+    }
+
     /// Read a 'Buffer<u8>' from a 'Dataset'.
     /// # Arguments
     /// * band_index - the band_index
@@ -135,7 +149,7 @@ impl Dataset {
         window: (isize, isize),
         window_size: (usize, usize),
         size: (usize, usize)
-        ) -> ByteBuffer
+    ) -> Option<ByteBuffer>
     {
         self.read_raster_as::<u8>(
             band_index,
@@ -151,22 +165,9 @@ impl Dataset {
     pub fn read_full_raster_as<T: Copy + GdalType>(
         &self,
         band_index: isize,
-    ) -> Buffer<T>
+    ) -> Option<Buffer<T>>
     {
-        let size_x;
-        let size_y;
-
-        unsafe{
-            size_x = gdal::GDALGetRasterXSize(self.c_dataset) as usize;
-            size_y = gdal::GDALGetRasterYSize(self.c_dataset) as usize;
-        }
-
-        self.read_raster_as::<T>(
-            band_index,
-            (0, 0),
-            (size_x, size_y),
-            (size_y, size_y)
-        )
+        self.get_rasterband(band_index).map(|band| band.read_band_as())
     }
 
     /// Read a 'Buffer<T>' from a 'Dataset'. T implements 'GdalType'
@@ -181,34 +182,9 @@ impl Dataset {
         window: (isize, isize),
         window_size: (usize, usize),
         size: (usize, usize),
-    ) -> Buffer<T>
+    ) -> Option<Buffer<T>>
     {
-        let pixels = (size.0 * size.1) as usize;
-        let mut data: Vec<T> = Vec::with_capacity(pixels);
-        //let no_data:
-        unsafe {
-            let c_band = gdal::GDALGetRasterBand(self.c_dataset, band_index as c_int);
-            let rv = gdal::GDALRasterIO(
-                c_band,
-                GDALRWFlag::GF_Read,
-                window.0 as c_int,
-                window.1 as c_int,
-                window_size.0 as c_int,
-                window_size.1 as c_int,
-                data.as_mut_ptr() as *const c_void,
-                size.0 as c_int,
-                size.1 as c_int,
-                T::gdal_type(),
-                0,
-                0
-            ) as isize;
-            assert!(rv == 0);
-            data.set_len(pixels);
-        };
-        Buffer{
-            size: size,
-            data: data,
-        }
+        self.get_rasterband(band_index).map(|band| band.read_as(window, window_size, size))
     }
 
     /// Write a 'Buffer<T>' into a 'Dataset'.
@@ -223,41 +199,9 @@ impl Dataset {
         window_size: (usize, usize),
         buffer: Buffer<T>
     ) {
-        assert_eq!(buffer.data.len(), buffer.size.0 * buffer.size.1);
-        unsafe {
-            let c_band = gdal::GDALGetRasterBand(self.c_dataset, band_index as c_int);
-            let rv = gdal::GDALRasterIO(
-                c_band,
-                GDALRWFlag::GF_Write,
-                window.0 as c_int,
-                window.1 as c_int,
-                window_size.0 as c_int,
-                window_size.1 as c_int,
-                buffer.data.as_ptr() as *const c_void,
-                buffer.size.0 as c_int,
-                buffer.size.1 as c_int,
-                T::gdal_type(),
-                0,
-                0
-            ) as isize;
-            assert!(rv == 0);
-        };
+        self.get_rasterband(band_index).expect("Invalid RasterBand").write(window, window_size, buffer)
     }
 
-
-    pub fn get_band_type(&self, band_index: isize) -> Option<GDALDataType> {
-
-        let band_count = self.count();
-        if band_index < 1 || band_count < band_index {
-            return None
-        }
-
-        let gdal_type: c_int;
-        unsafe{
-            gdal_type = gdal::GDALGetRasterDataType(gdal::GDALGetRasterBand(self.c_dataset, band_index as c_int));
-        }
-        Some(GDALDataType::from_c_int(gdal_type))
-    }
 }
 
 pub struct Buffer<T: GdalType> {

--- a/src/raster/driver.rs
+++ b/src/raster/driver.rs
@@ -97,7 +97,7 @@ impl Driver {
 }
 
 impl MajorObject for Driver {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+    unsafe fn gdal_object_ptr(&self) -> *const c_void {
         return self.c_driver;
     }
 }

--- a/src/raster/gdal.rs
+++ b/src/raster/gdal.rs
@@ -3,6 +3,7 @@ use super::gdal_enums::*;
 
 #[link(name="gdal")]
 extern {
+    // driver
     pub fn GDALAllRegister();
     pub fn GDALGetDriverByName(pszName: *const c_char) -> *const c_void;
     pub fn GDALGetDriverShortName(hDriver: *const c_void) -> *const c_char;
@@ -26,17 +27,22 @@ extern {
             pProgressData: *const c_void
         ) -> *const c_void;
     pub fn GDALOpen(pszFilename: *const c_char, eAccess: GDALAccess) -> *const c_void;
+    // dataset
     pub fn GDALClose(hDS: *const c_void);
     pub fn GDALGetDatasetDriver(hDataset: *const c_void) -> *const c_void;
     pub fn GDALGetRasterXSize(hDataset: *const c_void) -> c_int;
     pub fn GDALGetRasterYSize(hDataset: *const c_void) -> c_int;
     pub fn GDALGetRasterCount(hDataset: *const c_void) -> c_int;
+    pub fn GDALGetProjectionRef(hDataset: *const c_void) -> *const c_char;
+    pub fn GDALSetProjection(hDataset: *const c_void, pszProjection: *const c_char) -> c_int;
+    pub fn GDALSetGeoTransform(hDataset: *const c_void, padfTransform: *const c_double) -> c_int;
+    pub fn GDALGetGeoTransform(hDataset: *const c_void, padfTransform: *mut c_double) -> c_int;
+    pub fn GDALGetRasterBand(hDataset: *const c_void, nBandId: c_int) -> *const c_void;
+    // band
     pub fn GDALGetRasterDataType(hBand: *const c_void) -> c_int;
-    pub fn GDALGetProjectionRef(hDS: *const c_void) -> *const c_char;
-    pub fn GDALSetProjection(hDS: *const c_void, pszProjection: *const c_char) -> c_int;
-    pub fn GDALSetGeoTransform(hDS: *const c_void, padfTransform: *const c_double) -> c_int;
-    pub fn GDALGetGeoTransform(hDS: *const c_void, padfTransform: *mut c_double) -> c_int;
-    pub fn GDALGetRasterBand(hDS: *const c_void, nBandId: c_int) -> *const c_void;
+    pub fn GDALGetRasterNoDataValue(hBand: *const c_void, pbSuccess: *mut c_int) -> c_double;
+    pub fn GDALGetRasterOffset(hBand: *const c_void, pbSuccess: *mut c_int) -> c_double;
+    pub fn GDALGetRasterScale(hBand: *const c_void, pbSuccess: *mut c_int) -> c_double;
     pub fn GDALRasterIO(
             hBand: *const c_void,
             eRWFlag: GDALRWFlag,

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -3,6 +3,7 @@
 pub use raster::dataset::{Dataset, Buffer, ByteBuffer};
 pub use raster::driver::Driver;
 pub use raster::warp::reproject;
+pub use raster::rasterband::{RasterBand};
 
 mod gdal;
 mod types;
@@ -10,6 +11,7 @@ mod gdal_enums;
 pub mod dataset;
 pub mod driver;
 pub mod warp;
+pub mod rasterband;
 
 #[cfg(test)]
 mod tests;

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -1,0 +1,160 @@
+use libc::{c_int, c_void};
+use raster::{gdal, Dataset, Buffer};
+use raster::types::{GdalType};
+use raster::gdal_enums;
+use gdal_major_object::MajorObject;
+use metadata::Metadata;
+
+pub struct RasterBand<'a> {
+    c_rasterband: *const c_void,
+    owning_dataset: &'a Dataset,
+}
+
+impl <'a> RasterBand<'a> {
+    pub fn owning_dataset(&self) -> &'a Dataset {
+        self.owning_dataset
+    }
+
+    pub unsafe fn _with_c_ptr(c_rasterband: *const c_void, owning_dataset: &'a Dataset) -> Self {
+        RasterBand { c_rasterband: c_rasterband, owning_dataset: owning_dataset }
+    }
+
+    /// Read a 'Buffer<T>' from a 'Dataset'. T implements 'GdalType'
+    /// # Arguments
+    /// * band_index - the band_index
+    /// * window - the window position from top left
+    /// * window_size - the window size (GDAL will interpolate data if window_size != buffer_size)
+    /// * buffer_size - the desired size of the 'Buffer'
+    pub fn read_as<T: Copy + GdalType>(
+        &self,
+        window: (isize, isize),
+        window_size: (usize, usize),
+        size: (usize, usize),
+    ) -> Buffer<T>
+    {
+        let pixels = (size.0 * size.1) as usize;
+        let mut data: Vec<T> = Vec::with_capacity(pixels);
+        //let no_data:
+        unsafe {
+            let rv = gdal::GDALRasterIO(
+                self.c_rasterband,
+                gdal_enums::GDALRWFlag::GF_Read,
+                window.0 as c_int,
+                window.1 as c_int,
+                window_size.0 as c_int,
+                window_size.1 as c_int,
+                data.as_mut_ptr() as *const c_void,
+                size.0 as c_int,
+                size.1 as c_int,
+                T::gdal_type(),
+                0,
+                0
+            ) as isize;
+            assert!(rv == 0);
+            data.set_len(pixels);
+        };
+        Buffer{
+            size: size,
+            data: data,
+        }
+    }
+
+    /// Read a full 'Dataset' as 'Buffer<T>'.
+    /// # Arguments
+    /// * band_index - the band_index
+    pub fn read_band_as<T: Copy + GdalType>(
+        &self,
+    ) -> Buffer<T>
+    {
+        let size = self.owning_dataset.size();
+        self.read_as::<T>(
+            (0, 0),
+            (size.0 as usize, size.1 as usize),
+            (size.0 as usize, size.1 as usize)
+        )
+    }
+
+    // Write a 'Buffer<T>' into a 'Dataset'.
+    /// # Arguments
+    /// * band_index - the band_index
+    /// * window - the window position from top left
+    /// * window_size - the window size (GDAL will interpolate data if window_size != Buffer.size)
+    pub fn write<T: GdalType+Copy>(
+        &self,
+        window: (isize, isize),
+        window_size: (usize, usize),
+        buffer: Buffer<T>
+    ) {
+        assert_eq!(buffer.data.len(), buffer.size.0 * buffer.size.1);
+        unsafe {
+            let rv = gdal::GDALRasterIO(
+                self.c_rasterband,
+                gdal_enums::GDALRWFlag::GF_Write,
+                window.0 as c_int,
+                window.1 as c_int,
+                window_size.0 as c_int,
+                window_size.1 as c_int,
+                buffer.data.as_ptr() as *const c_void,
+                buffer.size.0 as c_int,
+                buffer.size.1 as c_int,
+                T::gdal_type(),
+                0,
+                0
+            ) as isize;
+            assert!(rv == 0);
+        };
+    }
+
+    pub fn get_band_type(&self) -> gdal_enums::GDALDataType {
+
+        let gdal_type: c_int;
+        unsafe{
+            gdal_type = gdal::GDALGetRasterDataType(self.c_rasterband);
+        }
+        gdal_enums::GDALDataType::from_c_int(gdal_type)
+    }
+
+    pub fn get_no_data_value(&self) ->Option<f64> {
+        unsafe {
+            let mut pb_success: c_int = 1;
+            let raw_pb_success = &mut pb_success as *mut c_int;
+            let no_data = gdal::GDALGetRasterNoDataValue(self.c_rasterband, raw_pb_success);
+            if pb_success == 1 {
+                return Some(no_data as f64);
+            }
+        }
+        None
+    }
+
+    pub fn get_scale(&self) ->Option<f64> {
+        unsafe {
+            let mut pb_success: c_int = 1;
+            let raw_pb_success = &mut pb_success as *mut c_int;
+            let scale = gdal::GDALGetRasterScale(self.c_rasterband, raw_pb_success);
+            if pb_success == 1 {
+                return Some(scale as f64);
+            }
+        }
+        None
+    }
+
+    pub fn get_offset(&self) ->Option<f64> {
+        unsafe {
+            let mut pb_success: c_int = 1;
+            let raw_pb_success = &mut pb_success as *mut c_int;
+            let offset = gdal::GDALGetRasterOffset(self.c_rasterband, raw_pb_success);
+            if pb_success == 1 {
+                return Some(offset as f64);
+            }
+        }
+        None
+    }
+}
+
+impl<'a> MajorObject for RasterBand<'a> {
+    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+        self.c_rasterband
+    }
+}
+
+impl<'a> Metadata for RasterBand<'a> {}

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -105,7 +105,7 @@ impl <'a> RasterBand<'a> {
         };
     }
 
-    pub fn get_band_type(&self) -> gdal_enums::GDALDataType {
+    pub fn band_type(&self) -> gdal_enums::GDALDataType {
 
         let gdal_type: c_int;
         unsafe{
@@ -114,7 +114,7 @@ impl <'a> RasterBand<'a> {
         gdal_enums::GDALDataType::from_c_int(gdal_type)
     }
 
-    pub fn get_no_data_value(&self) ->Option<f64> {
+    pub fn no_data_value(&self) ->Option<f64> {
         unsafe {
             let mut pb_success: c_int = 1;
             let raw_pb_success = &mut pb_success as *mut c_int;
@@ -126,7 +126,7 @@ impl <'a> RasterBand<'a> {
         None
     }
 
-    pub fn get_scale(&self) ->Option<f64> {
+    pub fn scale(&self) ->Option<f64> {
         unsafe {
             let mut pb_success: c_int = 1;
             let raw_pb_success = &mut pb_success as *mut c_int;
@@ -138,7 +138,7 @@ impl <'a> RasterBand<'a> {
         None
     }
 
-    pub fn get_offset(&self) ->Option<f64> {
+    pub fn offset(&self) ->Option<f64> {
         unsafe {
             let mut pb_success: c_int = 1;
             let raw_pb_success = &mut pb_success as *mut c_int;
@@ -152,7 +152,7 @@ impl <'a> RasterBand<'a> {
 }
 
 impl<'a> MajorObject for RasterBand<'a> {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+    unsafe fn gdal_object_ptr(&self) -> *const c_void {
         self.c_rasterband
     }
 }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -60,7 +60,7 @@ fn test_read_raster() {
         (20, 30),
         (2, 3),
         (2, 3)
-    );
+    ).unwrap();
     assert_eq!(rv.size.0, 2);
     assert_eq!(rv.size.1, 3);
     assert_eq!(rv.data, vec!(7, 7, 7, 10, 8, 12));
@@ -92,7 +92,7 @@ fn test_write_raster() {
         (5, 5),
         (1, 1),
         (1, 1)
-    );
+    ).unwrap();
     assert_eq!(left.data[0], 50u8);
 
     // read a pixel from the right side
@@ -101,7 +101,7 @@ fn test_write_raster() {
         (15, 5),
         (1, 1),
         (1, 1)
-    );
+    ).unwrap();
     assert_eq!(right.data[0], 20u8);
 }
 
@@ -209,7 +209,7 @@ fn test_read_raster_as() {
         (20, 30),
         (2, 3),
         (2, 3)
-    );
+    ).unwrap();
     assert_eq!(rv.data, vec!(7, 7, 7, 10, 8, 12));
     assert_eq!(rv.size.0, 2);
     assert_eq!(rv.size.1, 3);
@@ -219,11 +219,9 @@ fn test_read_raster_as() {
 #[test]
 fn test_read_full_raster_as() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
-    let rv = dataset.read_full_raster_as::<u8>(1);
-    assert_eq!(rv.size.0, 50);
+    let rv = dataset.read_full_raster_as::<u8>(1).unwrap();
+    assert_eq!(rv.size.0, 100);
     assert_eq!(rv.size.1, 50);
-    assert_eq!(dataset.get_band_type(1), Some(GDALDataType::GDT_Byte));
-    //TODO: find a value to assert?
 }
 
 #[test]
@@ -232,4 +230,41 @@ fn test_get_band_type() {
     let dataset = driver.create("", 20, 10, 1).unwrap();
     assert_eq!(dataset.get_band_type(1), Some(GDALDataType::GDT_Byte));
     assert_eq!(dataset.get_band_type(2), None);
+}
+
+#[test]
+fn test_get_rasterband() {
+    let driver = Driver::get("MEM").unwrap();
+    let dataset = driver.create("", 20, 10, 1).unwrap();
+    let rasterband = dataset.get_rasterband(1);
+    assert!(rasterband.is_some())
+}
+
+#[test]
+fn test_get_no_data_value() {
+    let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
+    let rasterband = dataset.get_rasterband(1).unwrap();
+    let no_data_value = rasterband.get_no_data_value();
+    assert!(no_data_value.is_none());
+
+    // let dataset = Dataset::open(fixture!("bluemarble.tif")).unwrap();
+    // let rasterband = dataset.get_rasterband(1).unwrap();
+    // let no_data_value = rasterband.get_no_data_value();
+    // assert_eq!(no_data_value, Some(0.0));
+}
+
+#[test]
+fn test_get_scale() {
+    let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
+    let rasterband = dataset.get_rasterband(1).unwrap();
+    let scale = rasterband.get_scale();
+    assert_eq!(scale, Some(1.0));
+}
+
+#[test]
+fn test_get_offset() {
+    let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
+    let rasterband = dataset.get_rasterband(1).unwrap();
+    let offset = rasterband.get_offset();
+    assert_eq!(offset, Some(0.0));
 }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -118,7 +118,7 @@ fn test_get_dataset_driver() {
 fn test_get_description() {
 
     let driver = Driver::get("mem").unwrap();
-    assert_eq!(driver.get_description(), Some("MEM".to_owned()));
+    assert_eq!(driver.description(), Some("MEM".to_owned()));
 }
 
 #[test]
@@ -126,12 +126,12 @@ fn test_get_metadata_item() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
     let key = "None";
     let domain = "None";
-    let meta = dataset.get_metadata_item(key, domain);
+    let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, None);
 
     let key = "INTERLEAVE";
     let domain = "IMAGE_STRUCTURE";
-    let meta = dataset.get_metadata_item(key, domain);
+    let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, Some(String::from("PIXEL")));
 }
 
@@ -146,7 +146,7 @@ fn test_set_metadata_item() {
     let result = dataset.set_metadata_item(key, value, domain);
     assert_eq!(result, Ok(()));
 
-    let result = dataset.get_metadata_item(key, domain);
+    let result = dataset.metadata_item(key, domain);
     assert_eq!(Some(value.to_owned()), result);
 }
 
@@ -166,7 +166,7 @@ fn test_create_with_band_type() {
     assert_eq!(dataset.size(), (10, 20));
     assert_eq!(dataset.count(), 3);
     assert_eq!(dataset.driver().short_name(), "MEM");
-    assert_eq!(dataset.get_band_type(1), Some(GDALDataType::GDT_Float32))
+    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Float32))
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_read_raster_as() {
     assert_eq!(rv.data, vec!(7, 7, 7, 10, 8, 12));
     assert_eq!(rv.size.0, 2);
     assert_eq!(rv.size.1, 3);
-    assert_eq!(dataset.get_band_type(1), Some(GDALDataType::GDT_Byte));
+    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Byte));
 }
 
 #[test]
@@ -228,23 +228,23 @@ fn test_read_full_raster_as() {
 fn test_get_band_type() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 20, 10, 1).unwrap();
-    assert_eq!(dataset.get_band_type(1), Some(GDALDataType::GDT_Byte));
-    assert_eq!(dataset.get_band_type(2), None);
+    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Byte));
+    assert_eq!(dataset.band_type(2), None);
 }
 
 #[test]
 fn test_get_rasterband() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 20, 10, 1).unwrap();
-    let rasterband = dataset.get_rasterband(1);
+    let rasterband = dataset.rasterband(1);
     assert!(rasterband.is_some())
 }
 
 #[test]
 fn test_get_no_data_value() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
-    let rasterband = dataset.get_rasterband(1).unwrap();
-    let no_data_value = rasterband.get_no_data_value();
+    let rasterband = dataset.rasterband(1).unwrap();
+    let no_data_value = rasterband.no_data_value();
     assert!(no_data_value.is_none());
 
     // let dataset = Dataset::open(fixture!("bluemarble.tif")).unwrap();
@@ -256,15 +256,15 @@ fn test_get_no_data_value() {
 #[test]
 fn test_get_scale() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
-    let rasterband = dataset.get_rasterband(1).unwrap();
-    let scale = rasterband.get_scale();
+    let rasterband = dataset.rasterband(1).unwrap();
+    let scale = rasterband.scale();
     assert_eq!(scale, Some(1.0));
 }
 
 #[test]
 fn test_get_offset() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
-    let rasterband = dataset.get_rasterband(1).unwrap();
-    let offset = rasterband.get_offset();
+    let rasterband = dataset.rasterband(1).unwrap();
+    let offset = rasterband.offset();
     assert_eq!(offset, Some(0.0));
 }

--- a/src/vector/dataset.rs
+++ b/src/vector/dataset.rs
@@ -22,7 +22,7 @@ pub struct Dataset {
 }
 
 impl MajorObject for Dataset {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+    unsafe fn gdal_object_ptr(&self) -> *const c_void {
         self.c_dataset
     }
 }

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -23,7 +23,7 @@ pub struct Layer {
 }
 
 impl MajorObject for Layer {
-    unsafe fn get_gdal_object_ptr(&self) -> *const c_void {
+    unsafe fn gdal_object_ptr(&self) -> *const c_void {
         self.c_layer
     }
 }


### PR DESCRIPTION
This adds a `struct RasterBand` and moves all related functions from `Dataset` to `RasterBand`.
I'm not sure if the read/write functions in Dataset should be removed or stay as shortcuts. As requesting a `RasterBand` from a `Dataset` should return an `Option<RasterBand>` i adapted the shortcuts to reflect this... 

Additionally i added some more Rasterband specific functions and implemented Metadata #20 for RasterBand.