### PR TITLE
Replace Option with Result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/georust/rust-gdal"
 documentation = "https://georust.github.io/rust-gdal/"
 
 [dependencies]
-libc = "0.2.13"
+error-chain = "0.7.2"
+libc = "0.2.18"
 geo = "0.0.5"
 gdal-sys = { path = "gdal-sys", version = "0.1.0"}
 

--- a/examples/rasterband.rs
+++ b/examples/rasterband.rs
@@ -16,10 +16,11 @@ fn main() {
     println!("rasterband type: {:?}", rasterband.band_type());
     println!("rasterband scale: {:?}", rasterband.scale());
     println!("rasterband offset: {:?}", rasterband.offset());
-    let rv = rasterband.read_as::<u8>(
+    if let Ok(rv) = rasterband.read_as::<u8>(
         (20, 30),
         (2, 3),
         (2, 3)
-    );
-    println!("{:?}", rv.data);
+    ) {
+        println!("{:?}", rv.data);
+    }
 }

--- a/gdal-sys/src/cpl_error.rs
+++ b/gdal-sys/src/cpl_error.rs
@@ -1,0 +1,28 @@
+use libc::{c_int, c_char};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+#[repr(C)]
+pub enum CPLErr {
+  CE_None = 0,
+  CE_Debug = 1,
+  CE_Warning = 2,
+  CE_Failure = 3,
+  CE_Fatal = 4 
+}
+
+#[link(name="gdal")]
+extern {
+    /// Erase any traces of previous errors.
+    pub fn CPLErrorReset();
+
+    /// Fetch the last error number.
+    pub fn CPLGetLastErrorNo() -> c_int;
+    
+    /// Fetch the last error type.
+    pub fn CPLGetLastErrorType() -> CPLErr;
+
+    /// Get the last error message.    
+    pub fn CPLGetLastErrorMsg() -> *const c_char;
+}
+

--- a/gdal-sys/src/gdal.rs
+++ b/gdal-sys/src/gdal.rs
@@ -1,5 +1,6 @@
 use libc::{c_int, c_char, c_double, c_void};
-use super::gdal_enums::*;
+use gdal_enums::*;
+use cpl_error::{CPLErr};
 
 #[link(name="gdal")]
 extern {
@@ -35,8 +36,8 @@ extern {
     pub fn GDALGetRasterCount(hDataset: *const c_void) -> c_int;
     pub fn GDALGetProjectionRef(hDataset: *const c_void) -> *const c_char;
     pub fn GDALSetProjection(hDataset: *const c_void, pszProjection: *const c_char) -> c_int;
-    pub fn GDALSetGeoTransform(hDataset: *const c_void, padfTransform: *const c_double) -> c_int;
-    pub fn GDALGetGeoTransform(hDataset: *const c_void, padfTransform: *mut c_double) -> c_int;
+    pub fn GDALSetGeoTransform(hDataset: *const c_void, padfTransform: *const c_double) -> CPLErr;
+    pub fn GDALGetGeoTransform(hDataset: *const c_void, padfTransform: *mut c_double) -> CPLErr;
     pub fn GDALGetRasterBand(hDataset: *const c_void, nBandId: c_int) -> *const c_void;
     // band
     pub fn GDALGetRasterDataType(hBand: *const c_void) -> c_int;
@@ -56,7 +57,7 @@ extern {
             GDALDataType: GDALDataType,
             nPixelSpace: c_int,
             nLineSpace: c_int
-        ) -> c_int;
+        ) -> CPLErr;
     pub fn GDALReprojectImage(
         hSrcDS: *const c_void,
         pszSrcWKT: *const c_char,
@@ -68,7 +69,10 @@ extern {
         pfnProgress: *const c_void,
         pProgressArg: *const c_void,
         psOptions: *const c_void
-    ) -> c_int;
+    ) -> CPLErr;
+    pub fn GDALGetDescription(hGdalMayorObject: *const c_void) -> *const c_char;
+    pub fn GDALGetMetadataItem(hGdalMayorObject: *const c_void, pszName: *const c_char, pszDomain: *const c_char) -> *const c_char;
+    pub fn GDALSetMetadataItem(hGdalMayorObject: *const c_void, pszName: *const c_char, pszValue: *const c_char, pszDomain: *const c_char ) -> CPLErr;
 }
 
 pub static REPROJECT_MEMORY_LIMIT: c_double = 0.0;

--- a/gdal-sys/src/lib.rs
+++ b/gdal-sys/src/lib.rs
@@ -6,3 +6,7 @@ pub mod gdal_enums;
 
 // OGR modules
 pub mod ogr;
+pub mod ogr_enums;
+
+// cpl modules
+pub mod cpl_error;

--- a/gdal-sys/src/ogr.rs
+++ b/gdal-sys/src/ogr.rs
@@ -1,4 +1,5 @@
 use libc::{c_int, c_char, c_double, c_void};
+use ogr_enums::*;
 
 #[link(name="gdal")]
 extern {
@@ -13,7 +14,7 @@ extern {
     pub fn OGR_L_GetLayerDefn(hLayer: *const c_void) -> *const c_void;
     pub fn OGR_L_GetNextFeature(hLayer: *const c_void) -> *const c_void;
     pub fn OGR_L_SetSpatialFilter(hLayer: *const c_void, hGeom: *const c_void);
-    pub fn OGR_L_CreateFeature(hLayer: *const c_void, hFeat: *const c_void) -> c_int;
+    pub fn OGR_L_CreateFeature(hLayer: *const c_void, hFeat: *const c_void) -> OGRErr;
     pub fn OGR_FD_GetFieldCount(hDefn: *const c_void) -> c_int;
     pub fn OGR_FD_GetFieldDefn(hDefn: *const c_void, iField: c_int) -> *const c_void;
     pub fn OGR_F_Create(hDefn: *const c_void) -> *const c_void;
@@ -22,28 +23,26 @@ extern {
     pub fn OGR_F_GetFieldAsString(hFeat: *const c_void, iField: c_int) -> *const c_char;
     pub fn OGR_F_GetFieldAsDouble(hFeat: *const c_void, iField: c_int) -> c_double;
     pub fn OGR_F_GetGeometryRef(hFeat: *const c_void) -> *const c_void;
-    pub fn OGR_F_SetGeometryDirectly(hFeat: *const c_void, hGeom: *const c_void) -> c_int;
+    pub fn OGR_F_SetGeometryDirectly(hFeat: *const c_void, hGeom: *const c_void) -> OGRErr;
     pub fn OGR_F_Destroy(hFeat: *const c_void);
     pub fn OGR_G_CreateGeometry(eGeometryType: c_int) -> *const c_void;
-    pub fn OGR_G_CreateFromWkt(ppszData: &mut *const c_char, hSRS: *const c_void, phGeometry: &mut *const c_void) -> c_int;
+    pub fn OGR_G_CreateFromWkt(ppszData: &mut *const c_char, hSRS: *const c_void, phGeometry: &mut *const c_void) -> OGRErr;
     pub fn OGR_G_GetGeometryType(hGeom: *const c_void) -> c_int;
     pub fn OGR_G_GetPoint(hGeom: *const c_void, i: c_int, pdfX: &mut c_double, pdfY: &mut c_double, pdfZ: &mut c_double);
     pub fn OGR_G_GetPointCount(hGeom: *const c_void) -> c_int;
     pub fn OGR_G_SetPoint_2D(hGeom: *const c_void, i: c_int, dfX: c_double, dfY: c_double);
-    pub fn OGR_G_ExportToWkt(hGeom: *const c_void, ppszSrcText: &mut *const c_char) -> c_int;
+    pub fn OGR_G_ExportToWkt(hGeom: *const c_void, ppszSrcText: &mut *const c_char) -> OGRErr;
     pub fn OGR_G_ExportToJson(hGeometry: *const c_void) -> *const c_char;
     pub fn OGR_G_ConvexHull(hTarget: *const c_void) -> *const c_void;
     pub fn OGR_G_GetGeometryCount(hGeom: *const c_void) -> c_int;
     pub fn OGR_G_GetGeometryRef(hGeom: *const c_void, iSubGeom: c_int) -> *const c_void;
-    pub fn OGR_G_AddGeometryDirectly(hGeom: *const c_void, hNewSubGeom: *const c_void) -> c_int;
+    pub fn OGR_G_AddGeometryDirectly(hGeom: *const c_void, hNewSubGeom: *const c_void) -> OGRErr;
     pub fn OGR_G_DestroyGeometry(hGeom: *mut c_void);
     pub fn OGR_Fld_GetNameRef(hDefn: *const c_void) -> *const c_char;
     pub fn OGR_Fld_GetType(hDefn: *const c_void) -> c_int;
     pub fn OGRFree(ptr: *mut c_void);
     pub fn VSIFree(ptr: *mut c_void);
 }
-
-pub const OGRERR_NONE:            c_int = 0;
 
 pub const OFT_REAL:               c_int = 2;
 pub const OFT_STRING:             c_int = 4;

--- a/gdal-sys/src/ogr_enums.rs
+++ b/gdal-sys/src/ogr_enums.rs
@@ -1,0 +1,15 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+#[repr(C)]
+pub enum OGRErr {
+    OGRERR_NONE = 0,                       
+    OGRERR_NOT_ENOUGH_DATA = 1,
+    OGRERR_NOT_ENOUGH_MEMORY = 2,
+    OGRERR_UNSUPPORTED_GEOMETRY_TYPE = 3,
+    OGRERR_UNSUPPORTED_OPERATION = 4,
+    OGRERR_CORRUPT_DATA = 5,
+    OGRERR_FAILURE = 6,
+    OGRERR_UNSUPPORTED_SRS = 7,
+    OGRERR_INVALID_HANDLE = 8,
+    OGRERR_NON_EXISTING_FEATURE = 9
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,6 @@
 use libc::{c_int};
+use gdal_sys::cpl_error::CPLErr;
+use gdal_sys::ogr_enums::OGRErr;
 
 // Create the Error, ErrorKind, ResultExt, and Result types
 error_chain! {
@@ -8,13 +10,17 @@ error_chain! {
     }
 
     errors {
-        CplError(class: c_int, number: c_int, msg: String) {
+        CplError(class: CPLErr, number: c_int, msg: String) {
             description("GDAL internal error")
-            display("CPL error class: '{}', error number: '{}', error msg: '{}'", class, number, msg)
+            display("CPL error class: '{:?}', error number: '{}', error msg: '{}'", class, number, msg)
         }
         NullPointer(method_name: &'static str) {
             description("GDAL method returned a NULL pointer.")
-            display("GDAL method {} returned a NULL pointer.", method_name) 
+            display("GDAL method '{}' returned a NULL pointer.", method_name) 
+        }
+        OgrError(err: OGRErr, method_name: &'static str) {
+            description("OGR error")
+            display("OGR method '{}' returned error: '{:?}'", method_name, err)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,20 @@
+use libc::{c_int};
+
+// Create the Error, ErrorKind, ResultExt, and Result types
+error_chain! {
+    foreign_links {
+        FfiNulError(::std::ffi::NulError);
+        StrUtf8Error(::std::str::Utf8Error);
+    }
+
+    errors {
+        CplError(class: c_int, number: c_int, msg: String) {
+            description("GDAL internal error")
+            display("CPL error class: '{}', error number: '{}', error msg: '{}'", class, number, msg)
+        }
+        NullPointer(method_name: &'static str) {
+            description("GDAL method returned a NULL pointer.")
+            display("GDAL method {} returned a NULL pointer.", method_name) 
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,12 @@
 #![crate_name="gdal"]
 #![crate_type="lib"]
 
-
 extern crate libc;
 extern crate geo;
 extern crate gdal_sys;
+
+#[macro_use]
+extern crate error_chain;
 
 pub use version::version_info;
 
@@ -33,8 +35,4 @@ pub mod metadata;
 pub mod version;
 pub mod raster;
 pub mod vector;
-
-#[derive(Clone, Copy, PartialEq, Debug)]
-pub struct GdalError {
-    pub desc: &'static str,
-}
+pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! for feature in layer.features() {
 //!     let highway_field = feature.field("highway").unwrap();
 //!     let geometry = feature.geometry();
-//!     println!("{} {}", highway_field.as_string(), geometry.wkt());
+//!     println!("{} {}", highway_field.as_string(), geometry.wkt().unwrap());
 //! }
 //! ```
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,30 +1,24 @@
-use libc::{c_char, c_void, c_int};
 use utils::{_string};
 use std::ffi::{CString};
 use gdal_major_object::MajorObject;
-
-#[link(name="gdal")]
-extern {
-    fn GDALGetDescription(hGdalMayorObject: *const c_void) -> *const c_char;
-    fn GDALGetMetadataItem(hGdalMayorObject: *const c_void, pszName: *const c_char, pszDomain: *const c_char) -> *const c_char;
-    fn GDALSetMetadataItem(hGdalMayorObject: *const c_void, pszName: *const c_char, pszValue: *const c_char, pszDomain: *const c_char ) -> c_int;
-}
+use utils::{_last_cpl_err};
+use errors::*;
+use gdal_sys::{gdal, cpl_error};
 
 pub trait Metadata: MajorObject {
 
-    fn description(&self) -> Option<String>{
-        let c_res = unsafe { GDALGetDescription(self.gdal_object_ptr())};
+    fn description(&self) -> Result<String>{
+        let c_res = unsafe { gdal::GDALGetDescription(self.gdal_object_ptr())};
         if c_res.is_null() {
-            None
-        } else {
-             Some(_string(c_res))
+            return Err(ErrorKind::NullPointer("GDALGetDescription").into());
         }
+        Ok(_string(c_res))
     }
 
     fn metadata_item(&self, key: &str, domain: &str) -> Option<String> {
         if let Ok(c_key) = CString::new(key.to_owned()) {
             if let Ok(c_domain) = CString::new(domain.to_owned()){
-                let c_res = unsafe { GDALGetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_domain.as_ptr())};
+                let c_res = unsafe { gdal::GDALGetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_domain.as_ptr())};
                 if !c_res.is_null() {
                     return Some(_string(c_res));
                 }
@@ -33,18 +27,16 @@ pub trait Metadata: MajorObject {
         None
     }
 
-    fn set_metadata_item(&mut self, key: &str, value: &str, domain: &str) -> Result<(), ()> {
-        if let Ok(c_key) = CString::new(key.to_owned()){
-            if let Ok(c_domain) = CString::new(domain.to_owned()){
-                if let Ok(c_value) =  CString::new(value.to_owned()){
-                    let c_res = unsafe { GDALSetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_value.as_ptr(), c_domain.as_ptr())};
-                    if c_res == 0 {
-                        return Ok(());
-                    }
-                }
-            }
+    fn set_metadata_item(&mut self, key: &str, value: &str, domain: &str) -> Result<()> {
+        let c_key = CString::new(key.to_owned())?;
+        let c_domain = CString::new(domain.to_owned())?;
+        let c_value =  CString::new(value.to_owned())?;
+        
+        let c_res = unsafe { gdal::GDALSetMetadataItem(self.gdal_object_ptr(), c_key.as_ptr(), c_value.as_ptr(), c_domain.as_ptr())};
+        if c_res != cpl_error::CPLErr::CE_None {
+            return Err(_last_cpl_err(c_res).into());
         }
-        Err(())
+        Ok(())
     }
 
 }

--- a/src/raster/dataset.rs
+++ b/src/raster/dataset.rs
@@ -173,7 +173,7 @@ impl Dataset {
         band_index: isize,
     ) -> Result<Buffer<T>>
     {
-        self.rasterband(band_index).map(|band| band.read_band_as())
+        self.rasterband(band_index)?.read_band_as()
     }
 
     /// Read a 'Buffer<T>' from a 'Dataset'. T implements 'GdalType'
@@ -190,7 +190,7 @@ impl Dataset {
         size: (usize, usize),
     ) -> Result<Buffer<T>>
     {
-        self.rasterband(band_index).map(|band| band.read_as(window, window_size, size))
+        self.rasterband(band_index)?.read_as(window, window_size, size)
     }
 
     /// Write a 'Buffer<T>' into a 'Dataset'.

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -6,6 +6,7 @@ pub use raster::warp::reproject;
 pub use raster::rasterband::{RasterBand};
 
 pub use gdal_sys::gdal_enums;
+pub use gdal_sys::cpl_error::{CPLErr};
 
 mod types;
 pub mod dataset;

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -19,10 +19,10 @@ macro_rules! fixture {
 #[test]
 fn test_open() {
     let dataset = Dataset::open(fixture!("tinymarble.png"));
-    assert!(dataset.is_some());
+    assert!(dataset.is_ok());
 
     let missing_dataset = Dataset::open(fixture!("no_such_file.png"));
-    assert!(missing_dataset.is_none());
+    assert!(missing_dataset.is_err());
 }
 
 
@@ -79,12 +79,13 @@ fn test_write_raster() {
     };
 
     // epand it to fill the image (20x10)
-    dataset.write_raster(
+    let res = dataset.write_raster(
         1,
         (0, 0),
         (20, 10),
         raster
     );
+    assert!(res.is_ok());
 
     // read a pixel from the left side
     let left = dataset.read_raster(
@@ -118,7 +119,7 @@ fn test_get_dataset_driver() {
 fn test_get_description() {
 
     let driver = Driver::get("mem").unwrap();
-    assert_eq!(driver.description(), Some("MEM".to_owned()));
+    assert_eq!(driver.description().unwrap(), "MEM".to_string());
 }
 
 #[test]
@@ -144,7 +145,7 @@ fn test_set_metadata_item() {
     let domain = "Test_Domain";
     let value = "Test_Value";
     let result = dataset.set_metadata_item(key, value, domain);
-    assert_eq!(result, Ok(()));
+    assert!(result.is_ok());
 
     let result = dataset.metadata_item(key, domain);
     assert_eq!(Some(value.to_owned()), result);
@@ -166,7 +167,7 @@ fn test_create_with_band_type() {
     assert_eq!(dataset.size(), (10, 20));
     assert_eq!(dataset.count(), 3);
     assert_eq!(dataset.driver().short_name(), "MEM");
-    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Float32))
+    assert_eq!(dataset.band_type(1).unwrap(), GDALDataType::GDT_Float32)
 }
 
 #[test]
@@ -184,18 +185,18 @@ fn test_geo_transform() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 20, 10, 1).unwrap();
     let transform = [0., 1., 0., 0., 0., 1.];
-    dataset.set_geo_transform(&transform);
-    assert_eq!(dataset.geo_transform(), Some(transform));
+    assert!(dataset.set_geo_transform(&transform).is_ok());
+    assert_eq!(dataset.geo_transform().unwrap(), transform);
 }
 
 
 #[test]
 fn test_get_driver_by_name() {
     let missing_driver = Driver::get("wtf");
-    assert!(missing_driver.is_none());
+    assert!(missing_driver.is_err());
 
     let ok_driver = Driver::get("GTiff");
-    assert!(ok_driver.is_some());
+    assert!(ok_driver.is_ok());
     let driver = ok_driver.unwrap();
     assert_eq!(driver.short_name(), "GTiff");
     assert_eq!(driver.long_name(), "GeoTIFF");
@@ -213,7 +214,7 @@ fn test_read_raster_as() {
     assert_eq!(rv.data, vec!(7, 7, 7, 10, 8, 12));
     assert_eq!(rv.size.0, 2);
     assert_eq!(rv.size.1, 3);
-    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Byte));
+    assert_eq!(dataset.band_type(1).unwrap(), GDALDataType::GDT_Byte);
 }
 
 #[test]
@@ -228,8 +229,8 @@ fn test_read_full_raster_as() {
 fn test_get_band_type() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 20, 10, 1).unwrap();
-    assert_eq!(dataset.band_type(1), Some(GDALDataType::GDT_Byte));
-    assert_eq!(dataset.band_type(2), None);
+    assert_eq!(dataset.band_type(1).unwrap(), GDALDataType::GDT_Byte);
+    assert!(dataset.band_type(2).is_err());
 }
 
 #[test]
@@ -237,7 +238,7 @@ fn test_get_rasterband() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 20, 10, 1).unwrap();
     let rasterband = dataset.rasterband(1);
-    assert!(rasterband.is_some())
+    assert!(rasterband.is_ok())
 }
 
 #[test]

--- a/src/raster/warp.rs
+++ b/src/raster/warp.rs
@@ -2,9 +2,12 @@ use libc::c_double;
 use std::ptr::null;
 use raster::{Dataset};
 use raster::gdal_enums::GDALResampleAlg;
-use gdal_sys::gdal;
+use gdal_sys::{gdal, cpl_error};
+use utils::_last_cpl_err;
 
-pub fn reproject(src: &Dataset, dst: &Dataset) {
+use errors::*;
+
+pub fn reproject(src: &Dataset, dst: &Dataset) -> Result<()> {
     let rv = unsafe {
         gdal::GDALReprojectImage(
                 src._c_ptr(),
@@ -18,6 +21,9 @@ pub fn reproject(src: &Dataset, dst: &Dataset) {
                 null(),
                 null()
             )
-    } as isize;
-    assert!(rv == 0);
+    };
+    if rv != cpl_error::CPLErr::CE_None {            
+        return Err(_last_cpl_err(rv).into());
+    }
+    Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,20 @@
 use libc::c_char;
 use std::ffi::CStr;
-use std::str;
+use gdal_sys::cpl_error;
+
+use errors::*;
 
 
 pub fn _string(raw_ptr: *const c_char) -> String {
     let c_str = unsafe { CStr::from_ptr(raw_ptr) };
-    return str::from_utf8(c_str.to_bytes()).unwrap().to_string();
+    c_str.to_string_lossy().into_owned()
+}
+
+
+// TODO: inspect if this is sane...
+pub fn _last_cpl_err(cpl_err_class: cpl_error::CPLErr) -> ErrorKind {
+    let last_err_no = unsafe { cpl_error::CPLGetLastErrorNo() };
+    let last_err_msg = _string( unsafe { cpl_error::CPLGetLastErrorMsg() } );
+    unsafe { cpl_error::CPLErrorReset() };
+    ErrorKind::CplError(cpl_err_class, last_err_no, last_err_msg)
 }

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -34,7 +34,7 @@ impl<'a> Feature<'a> {
         }
         let field_defn = unsafe { ogr::OGR_F_GetFieldDefnRef(self.c_feature, field_id) };
         let field_type = unsafe { ogr::OGR_Fld_GetType(field_defn) };
-        return match field_type {
+        match field_type {
             ogr::OFT_STRING => {
                 let rv = unsafe { ogr::OGR_F_GetFieldAsString(self.c_feature, field_id) };
                 return Some(FieldValue::StringValue(_string(rv)));

--- a/src/vector/geo_to_gdal.rs
+++ b/src/vector/geo_to_gdal.rs
@@ -2,89 +2,90 @@ use libc::c_int;
 use vector::{Geometry, ToGdal};
 use geo;
 use gdal_sys::ogr;
+use errors::*;
 
 impl ToGdal for geo::Point {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_POINT);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_POINT)?;
         let &geo::Point(coordinate) = self;
         geom.set_point_2d(0, (coordinate.x, coordinate.y));
-        return geom;
+        Ok(geom)
     }
 }
 
 impl ToGdal for geo::MultiPoint {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_MULTIPOINT);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_MULTIPOINT)?;
         let &geo::MultiPoint(ref point_list) = self;
         for point in point_list.iter() {
-            geom.add_geometry(point.to_gdal());
+            geom.add_geometry(point.to_gdal()?)?;
         }
-        return geom;
+        Ok(geom)
     }
 }
 
-fn geometry_with_points(wkb_type: c_int, points: &geo::LineString) -> Geometry {
-    let mut geom = Geometry::empty(wkb_type);
+fn geometry_with_points(wkb_type: c_int, points: &geo::LineString) -> Result<Geometry> {
+    let mut geom = Geometry::empty(wkb_type)?;
     let &geo::LineString(ref linestring) = points;
     for (i, &geo::Point(coordinate)) in linestring.iter().enumerate() {
         geom.set_point_2d(i, (coordinate.x, coordinate.y));
     }
-    return geom;
+    Ok(geom)
 }
 
 impl ToGdal for geo::LineString {
-    fn to_gdal(&self) -> Geometry {
+    fn to_gdal(&self) -> Result<Geometry> {
         geometry_with_points(ogr::WKB_LINESTRING, self)
     }
 }
 
 impl ToGdal for geo::MultiLineString {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_MULTILINESTRING);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_MULTILINESTRING)?;
         let &geo::MultiLineString(ref point_list) = self;
         for point in point_list.iter() {
-            geom.add_geometry(point.to_gdal());
+            geom.add_geometry(point.to_gdal()?)?;
         }
-        return geom;
+        Ok(geom)
     }
 }
 
 impl ToGdal for geo::Polygon {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_POLYGON);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_POLYGON)?;
         let &geo::Polygon(ref outer, ref holes) = self;
-        geom.add_geometry(geometry_with_points(ogr::WKB_LINEARRING, outer));
+        geom.add_geometry(geometry_with_points(ogr::WKB_LINEARRING, outer)?)?;
         for ring in holes.iter() {
-            geom.add_geometry(geometry_with_points(ogr::WKB_LINEARRING, ring));
+            geom.add_geometry(geometry_with_points(ogr::WKB_LINEARRING, ring)?)?;
         }
-        return geom;
+        Ok(geom)
     }
 }
 
 impl ToGdal for geo::MultiPolygon {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_MULTIPOLYGON);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_MULTIPOLYGON)?;
         let &geo::MultiPolygon(ref polygon_list) = self;
         for polygon in polygon_list.iter() {
-            geom.add_geometry(polygon.to_gdal());
+            geom.add_geometry(polygon.to_gdal()?)?;
         }
-        return geom;
+        Ok(geom)
     }
 }
 
 impl ToGdal for geo::GeometryCollection {
-    fn to_gdal(&self) -> Geometry {
-        let mut geom = Geometry::empty(ogr::WKB_GEOMETRYCOLLECTION);
+    fn to_gdal(&self) -> Result<Geometry> {
+        let mut geom = Geometry::empty(ogr::WKB_GEOMETRYCOLLECTION)?;
         let &geo::GeometryCollection(ref item_list) = self;
         for item in item_list.iter() {
-            geom.add_geometry(item.to_gdal());
+            geom.add_geometry(item.to_gdal()?)?;
         }
-        return geom;
+        Ok(geom)
     }
 }
 
 impl ToGdal for geo::Geometry {
-    fn to_gdal(&self) -> Geometry {
+    fn to_gdal(&self) -> Result<Geometry> {
         return match *self {
             geo::Geometry::Point(ref c) => c.to_gdal(),
             geo::Geometry::MultiPoint(ref c) => c.to_gdal(),

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -11,7 +11,7 @@
 //! for feature in layer.features() {
 //!     let highway_field = feature.field("highway").unwrap();
 //!     let geometry = feature.geometry();
-//!     println!("{} {}", highway_field.as_string(), geometry.wkt());
+//!     println!("{} {}", highway_field.as_string(), geometry.wkt().unwrap());
 //! }
 //! ```
 

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -23,9 +23,11 @@ pub use vector::defn::{Defn, FieldIterator, Field};
 pub use vector::feature::{Feature, FieldValue};
 pub use vector::geometry::Geometry;
 
+use errors::{Result};
+
 /// Convert object to a GDAL geometry.
 pub trait ToGdal {
-    fn to_gdal(&self) -> Geometry;
+    fn to_gdal(&self) -> Result<Geometry>;
 }
 
 mod driver;

--- a/src/vector/tests/convert_geo.rs
+++ b/src/vector/tests/convert_geo.rs
@@ -8,8 +8,8 @@ fn test_import_export_point() {
     let coord = geo::Coordinate{x: 1., y: 2.};
     let geo = geo::Geometry::Point(geo::Point(coord));
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -22,8 +22,8 @@ fn test_import_export_multipoint() {
     );
     let geo = geo::Geometry::MultiPoint(geo::MultiPoint(coord));
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -36,8 +36,8 @@ fn test_import_export_linestring() {
     );
     let geo = geo::Geometry::LineString(geo::LineString(coord));
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -57,8 +57,8 @@ fn test_import_export_multilinestring() {
     );
     let geo = geo::Geometry::MultiLineString(geo::MultiLineString(strings));
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 fn square(x0: isize, y0: isize, x1: isize, y1: isize) -> geo::LineString {
@@ -80,8 +80,8 @@ fn test_import_export_polygon() {
     let holes = vec!(square(1, 1, 2, 2), square(3, 3, 4, 4));
     let geo = geo::Geometry::Polygon(geo::Polygon(outer, holes));
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -106,8 +106,8 @@ fn test_import_export_multipolygon() {
     ));
     let geo = geo::Geometry::MultiPolygon(multipolygon);
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -124,6 +124,6 @@ fn test_import_export_geometrycollection() {
     let collection = geo::GeometryCollection(vec!(point, linestring));
     let geo = geo::Geometry::GeometryCollection(collection);
 
-    assert_eq!(Geometry::from_wkt(wkt).to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt(), wkt);
+    assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
+    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
 }

--- a/src/vector/tests/convert_geo.rs
+++ b/src/vector/tests/convert_geo.rs
@@ -9,7 +9,7 @@ fn test_import_export_point() {
     let geo = geo::Geometry::Point(geo::Point(coord));
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn test_import_export_multipoint() {
     let geo = geo::Geometry::MultiPoint(geo::MultiPoint(coord));
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn test_import_export_linestring() {
     let geo = geo::Geometry::LineString(geo::LineString(coord));
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn test_import_export_multilinestring() {
     let geo = geo::Geometry::MultiLineString(geo::MultiLineString(strings));
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 fn square(x0: isize, y0: isize, x1: isize, y1: isize) -> geo::LineString {
@@ -81,7 +81,7 @@ fn test_import_export_polygon() {
     let geo = geo::Geometry::Polygon(geo::Polygon(outer, holes));
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn test_import_export_multipolygon() {
     let geo = geo::Geometry::MultiPolygon(multipolygon);
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }
 
 #[test]
@@ -125,5 +125,5 @@ fn test_import_export_geometrycollection() {
     let geo = geo::Geometry::GeometryCollection(collection);
 
     assert_eq!(Geometry::from_wkt(wkt).unwrap().to_geo(), geo);
-    assert_eq!(geo.to_gdal().wkt().unwrap(), wkt);
+    assert_eq!(geo.to_gdal().unwrap().wkt().unwrap(), wkt);
 }

--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -115,7 +115,7 @@ fn test_json() {
             "[ 26.1019382, 44.4303191 ], ",
             "[ 26.1020002, 44.4304202 ] ] }"
             ).to_string();
-        assert_eq!(json, json_ok);
+        assert_eq!(json.unwrap(), json_ok);
     });
 }
 
@@ -138,7 +138,7 @@ fn test_schema() {
 #[test]
 fn test_create_bbox() {
     let bbox = Geometry::bbox(-27., 33., 52., 85.).unwrap();
-    assert_eq!(bbox.json(), "{ \"type\": \"Polygon\", \"coordinates\": [ [ [ -27.0, 85.0 ], [ 52.0, 85.0 ], [ 52.0, 33.0 ], [ -27.0, 33.0 ], [ -27.0, 85.0 ] ] ] }");
+    assert_eq!(bbox.json().unwrap(), "{ \"type\": \"Polygon\", \"coordinates\": [ [ [ -27.0, 85.0 ], [ 52.0, 85.0 ], [ 52.0, 33.0 ], [ -27.0, 33.0 ], [ -27.0, 85.0 ] ] ] }");
 }
 
 #[test]

--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -95,7 +95,7 @@ fn test_missing_field() {
 #[test]
 fn test_wkt() {
     with_first_feature("roads.geojson", |feature| {
-        let wkt = feature.geometry().wkt();
+        let wkt = feature.geometry().wkt().unwrap();
         let wkt_ok = format!("{}{}",
             "LINESTRING (26.1019276 44.4302748,",
             "26.1019382 44.4303191,26.1020002 44.4304202)"
@@ -137,7 +137,7 @@ fn test_schema() {
 
 #[test]
 fn test_create_bbox() {
-    let bbox = Geometry::bbox(-27., 33., 52., 85.);
+    let bbox = Geometry::bbox(-27., 33., 52., 85.).unwrap();
     assert_eq!(bbox.json(), "{ \"type\": \"Polygon\", \"coordinates\": [ [ [ -27.0, 85.0 ], [ 52.0, 85.0 ], [ 52.0, 33.0 ], [ -27.0, 33.0 ], [ -27.0, 85.0 ] ] ] }");
 }
 
@@ -149,7 +149,7 @@ fn test_spatial_filter() {
     let all_features: Vec<Feature> = layer.features().collect();
     assert_eq!(all_features.len(), 21);
 
-    let bbox = Geometry::bbox(26.1017, 44.4297, 26.1025, 44.4303);
+    let bbox = Geometry::bbox(26.1017, 44.4297, 26.1025, 44.4303).unwrap();
     layer.set_spatial_filter(&bbox);
 
     let some_features: Vec<Feature> = layer.features().collect();
@@ -165,7 +165,7 @@ fn test_spatial_filter() {
 fn test_convex_hull() {
     let star = "POLYGON ((0 1,3 1,1 3,1.5 0.0,2 3,0 1))";
     let hull = "POLYGON ((1.5 0.0,0 1,1 3,2 3,3 1,1.5 0.0))";
-    assert_eq!(Geometry::from_wkt(star).convex_hull().wkt(), hull);
+    assert_eq!(Geometry::from_wkt(star).unwrap().convex_hull().unwrap().wkt().unwrap(), hull);
 }
 
 #[test]
@@ -175,8 +175,8 @@ fn test_write_features() {
     {
         let driver = Driver::get("GeoJSON").unwrap();
         let mut ds = driver.create(fixture!("output.geojson")).unwrap();
-        let mut layer = ds.create_layer();
-        layer.create_feature(Geometry::from_wkt("POINT (1 2)"));
+        let mut layer = ds.create_layer().unwrap();
+        layer.create_feature(Geometry::from_wkt("POINT (1 2)").unwrap()).unwrap();
         // dataset is closed here
     }
 
@@ -184,7 +184,7 @@ fn test_write_features() {
     fs::remove_file(fixture!("output.geojson")).unwrap();
     let layer = ds.layer(0).unwrap();
     let wkt_list = layer.features()
-        .map(|f| f.geometry().wkt())
+        .map(|f| f.geometry().wkt().unwrap())
         .collect::<Vec<String>>();
     assert_eq!(wkt_list, vec!("POINT (1 2)"));
 }


### PR DESCRIPTION
I started replacing Option (and panics) with Result #28 . Everything should work but the `ToGdal` trait needs some attention:

```
pub trait ToGdal {
    fn to_gdal(&self) -> Geometry;
}
```

Since the creation of a new `Geometry` can fail in GDAL there are now many unused Results in the `geo_to_gdal` module. Instead of using `unwrap()` i would suggest to change the trait to return a `Result`:

```
pub trait ToGdal {
    fn to_gdal(&self) -> Result<Geometry>;
}
```