### PR TITLE
remove unwraps and add more error msgs.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,9 +14,9 @@ error_chain! {
             description("GDAL internal error")
             display("CPL error class: '{:?}', error number: '{}', error msg: '{}'", class, number, msg)
         }
-        NullPointer(method_name: &'static str) {
+        NullPointer(method_name: &'static str, msg: String) {
             description("GDAL method returned a NULL pointer.")
-            display("GDAL method '{}' returned a NULL pointer.", method_name)
+            display("GDAL method '{}' returned a NULL pointer. Error msg: '{}'", method_name, msg)
         }
         OgrError(err: OGRErr, method_name: &'static str) {
             description("OGR error")

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,7 @@
 use utils::{_string};
 use std::ffi::{CString};
 use gdal_major_object::MajorObject;
-use utils::{_last_cpl_err};
+use utils::{_last_cpl_err, _last_null_pointer_err};
 use errors::*;
 use gdal_sys::{gdal, cpl_error};
 
@@ -10,7 +10,7 @@ pub trait Metadata: MajorObject {
     fn description(&self) -> Result<String>{
         let c_res = unsafe { gdal::GDALGetDescription(self.gdal_object_ptr())};
         if c_res.is_null() {
-            return Err(ErrorKind::NullPointer("GDALGetDescription").into());
+            return Err(_last_null_pointer_err("GDALGetDescription").into());
         }
         Ok(_string(c_res))
     }

--- a/src/raster/driver.rs
+++ b/src/raster/driver.rs
@@ -1,7 +1,7 @@
 use libc::{c_int, c_void};
 use std::ffi::CString;
 use std::sync::{Once, ONCE_INIT};
-use utils::_string;
+use utils::{_string, _last_null_pointer_err};
 use raster::{Dataset};
 use raster::types::GdalType;
 use gdal_major_object::MajorObject;
@@ -30,10 +30,10 @@ pub struct Driver {
 impl Driver {
     pub fn get(name: &str) -> Result<Driver> {
         _register_drivers();
-        let c_name = CString::new(name.as_bytes()).unwrap();
+        let c_name = CString::new(name)?;
         let c_driver = unsafe { gdal::GDALGetDriverByName(c_name.as_ptr()) };
         if c_driver.is_null() {
-            return Err(ErrorKind::NullPointer("GDALGetDriverByName").into());
+            return Err(_last_null_pointer_err("GDALGetDriverByName").into());
         };
         Ok(Driver{c_driver: c_driver})
     }
@@ -79,7 +79,7 @@ impl Driver {
         bands: isize,
     ) -> Result<Dataset> {
         use std::ptr::null;
-        let c_filename = CString::new(filename.as_bytes()).unwrap();
+        let c_filename = CString::new(filename)?;
         let c_dataset = unsafe { gdal::GDALCreate(
                 self.c_driver,
                 c_filename.as_ptr(),
@@ -90,7 +90,7 @@ impl Driver {
                 null()
             ) };
         if c_dataset.is_null() {
-            return Err(ErrorKind::NullPointer("GDALCreate").into());
+            return Err(_last_null_pointer_err("GDALCreate").into());
         };
         Ok( unsafe { Dataset::_with_c_ptr(c_dataset) } )        
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,3 +18,9 @@ pub fn _last_cpl_err(cpl_err_class: cpl_error::CPLErr) -> ErrorKind {
     unsafe { cpl_error::CPLErrorReset() };
     ErrorKind::CplError(cpl_err_class, last_err_no, last_err_msg)
 }
+
+pub fn _last_null_pointer_err(method_name: &'static str) -> ErrorKind {
+    let last_err_msg = _string( unsafe { cpl_error::CPLGetLastErrorMsg() } );
+    unsafe { cpl_error::CPLErrorReset() };
+    ErrorKind::NullPointer(method_name, last_err_msg)
+}

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -6,6 +6,7 @@ use vector::defn::Defn;
 use gdal_major_object::MajorObject;
 use metadata::Metadata;
 use gdal_sys::{ogr, ogr_enums};
+use utils::{_last_null_pointer_err};
 
 use errors::*;
 
@@ -136,7 +137,7 @@ impl FieldDefn {
         let c_str = CString::new(name)?;
         let c_obj = unsafe { ogr::OGR_Fld_Create(c_str.as_ptr(), field_type) };
         if c_obj.is_null() {
-            return Err(ErrorKind::NullPointer("OGR_Fld_Create").into());
+            return Err(_last_null_pointer_err("OGR_Fld_Create").into());
         };
         Ok(FieldDefn { c_obj: c_obj})
     }


### PR DESCRIPTION
This removes most `.unwrap()` calls from library methods and updates dependency versions.
Additionally `ErrorKind::NullPointer` now tries to get a GDAL error msg.