### PR TITLE
A better fix for issue #45

### DIFF
--- a/gdal-sys/src/osr.rs
+++ b/gdal-sys/src/osr.rs
@@ -6,7 +6,7 @@ use ogr_enums::*;
 extern {
     pub fn OSRNewSpatialReference(pszWKT: *const c_char) -> *mut c_void;
     pub fn OSRClone(hSRS: *const c_void) -> *mut c_void;
-    pub fn OSRDestroySpatialReference(hSRS: *mut c_void) -> c_void;
+    pub fn OSRRelease(hSRS: *mut c_void) -> c_void;
     pub fn OSRSetFromUserInput(hSRS: *mut c_void, pszDefinition: *const c_char) -> OGRErr;
     pub fn OSRImportFromEPSG(hSRS: *const c_void, nCode: c_int) -> OGRErr;
     pub fn OSRImportFromProj4(hSRS: *mut c_void, proj4_string: *const c_char) -> OGRErr;

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -49,7 +49,7 @@ pub struct SpatialRef(*mut c_void);
 
 impl Drop for SpatialRef {
     fn drop(&mut self){
-        unsafe { osr::OSRDestroySpatialReference(self.0)};
+        unsafe { osr::OSRRelease(self.0)};
         self.0 = ptr::null_mut();
     }
 }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -273,8 +273,8 @@ impl Geometry {
         }
     }
 
-    pub fn set_spatial_reference(&mut self, spatial_ref: &SpatialRef) {
-        unsafe { ogr::OGR_G_AssignSpatialReference(self.c_geometry(), (*spatial_ref).to_c_hsrs()) };
+    pub fn set_spatial_reference(&mut self, spatial_ref: SpatialRef) {
+        unsafe { ogr::OGR_G_AssignSpatialReference(self.c_geometry(), spatial_ref.to_c_hsrs()) };
     }
 }
 
@@ -340,7 +340,7 @@ mod tests {
         assert!(geom.spatial_reference().is_none());
 
         let srs = SpatialRef::from_epsg(4326).unwrap();
-        geom.set_spatial_reference(&srs);
+        geom.set_spatial_reference(srs);
         assert!(geom.spatial_reference().is_some());
     }
 }


### PR DESCRIPTION
This reverts the previous fix and changes the impl of Drop for SpatialRef
to use OSGRelease instead of OSRDestroySpatialReference. This will just
decrement the reference count for the SpatialRef and destroy it if the
count reaches 0.

This resolves a valgrind error that was still being reported after the previous
fix. This fix also has the advantage that it does not change the API for
existing users.