### PR TITLE
Wrap OGR_L_GetExtent

### DIFF
--- a/gdal-sys/src/lib.rs
+++ b/gdal-sys/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gdal_enums;
 // OGR modules
 pub mod ogr;
 pub mod ogr_enums;
+pub mod ogr_structs;
 
 // OGR Spatial Reference module
 pub mod osr;

--- a/gdal-sys/src/ogr.rs
+++ b/gdal-sys/src/ogr.rs
@@ -1,5 +1,6 @@
 use libc::{c_int, c_char, c_double, c_void};
 use ogr_enums::*;
+pub use ogr_structs::*;
 
 // http://gdal.org/ogr__api_8h.html
 
@@ -19,6 +20,7 @@ extern {
     pub fn OGR_L_SetSpatialFilter(hLayer: *const c_void, hGeom: *const c_void);
     pub fn OGR_L_CreateFeature(hLayer: *const c_void, hFeat: *const c_void) -> OGRErr;
     pub fn OGR_L_CreateField(hLayer: *const c_void, hField: *const c_void, bApproxOK: c_int) -> OGRErr;
+    pub fn OGR_L_GetExtent(hLayer: *const c_void, pEnvelope: &mut OGREnvelope, bForce: c_int) -> OGRErr;
     pub fn OGR_FD_GetFieldCount(hDefn: *const c_void) -> c_int;
     pub fn OGR_FD_GetFieldDefn(hDefn: *const c_void, iField: c_int) -> *const c_void;
     pub fn OGR_FD_GetGeomFieldCount(hDefn: *const c_void) -> c_int;

--- a/gdal-sys/src/ogr_structs.rs
+++ b/gdal-sys/src/ogr_structs.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct OGREnvelope {
+    pub MinX: f64,
+    pub MaxX: f64,
+    pub MinY: f64,
+    pub MaxY: f64,
+}
+
+impl Default for OGREnvelope {
+    fn default() -> Self {
+        Self {
+            MinX: 0.0,
+            MaxX: 0.0,
+            MinY: 0.0,
+            MaxY: 0.0,
+        }
+    }
+}

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -97,6 +97,16 @@ impl Layer {
         ft.create(self)?;
         Ok(())
     }
+
+    pub fn get_extent(&self, force: bool) -> Result<ogr::OGREnvelope> {
+        let mut envelope = ogr::OGREnvelope::default();
+        let force = if force { 1 } else { 0 };
+        let rv = unsafe { ogr::OGR_L_GetExtent(self.c_layer, &mut envelope, force) };
+        if rv != ogr_enums::OGRErr::OGRERR_NONE {
+            return Err(ErrorKind::OgrError(rv, "OGR_L_GetExtent").into());
+        }
+        Ok(envelope)
+    }
 }
 
 pub struct FeatureIterator<'a> {

--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -30,6 +30,18 @@ fn test_layer_count() {
     assert_eq!(ds.count(), 1);
 }
 
+#[test]
+fn test_layer_extent() {
+    let mut ds = Dataset::open(fixture!("roads.geojson")).unwrap();
+    let layer = ds.layer(0).unwrap();
+    assert!(layer.get_extent(false).is_err());
+    let extent = layer.get_extent(true).unwrap();
+    assert_almost_eq(extent.MinX, 26.100768);
+    assert_almost_eq(extent.MaxX, 26.103515);
+    assert_almost_eq(extent.MinY, 44.429858);
+    assert_almost_eq(extent.MaxY, 44.431818);
+}
+
 
 fn with_features<F>(name: &str, f: F) where F: Fn(FeatureIterator) {
     let mut ds = Dataset::open(fixture!(name)).unwrap();


### PR DESCRIPTION
I'm not sure whether it's all right to expose `OGREnvelope` directly, any preferences?